### PR TITLE
fix: interpretation of empty strings

### DIFF
--- a/domain/src/main/java/org/citybackend/city/City.java
+++ b/domain/src/main/java/org/citybackend/city/City.java
@@ -6,7 +6,6 @@ import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeParseException;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.TimeZone;
@@ -352,17 +351,21 @@ public class City {
     }
 
     public Builder latitude(String latitude) {
-      Double lat = Double.valueOf(latitude);
-      if (LAT_MIN <= lat && lat <= LAT_MAX) {
-        this.latitude = lat;
+      if (!latitude.isEmpty()) {
+        Double lat = Double.valueOf(latitude);
+        if (LAT_MIN <= lat && lat <= LAT_MAX) {
+          this.latitude = lat;
+        }
       }
       return this;
     }
 
     public Builder longitude(String longitude) {
-      Double lng = Double.valueOf(longitude);
-      if (LNG_MIN <= lng && lng <= LNG_MAX) {
-        this.longitude = lng;
+      if (!longitude.isEmpty()) {
+        Double lng = Double.valueOf(longitude);
+        if (LNG_MIN <= lng && lng <= LNG_MAX) {
+          this.longitude = lng;
+        }
       }
       return this;
     }
@@ -408,12 +411,16 @@ public class City {
     }
 
     public Builder elevation(String elevation) {
-      this.elevation = Integer.valueOf(elevation);
+      if (!elevation.isEmpty()) {
+        this.elevation = Integer.valueOf(elevation);
+      }
       return this;
     }
 
     public Builder dem(String dem) {
-      this.dem = Integer.valueOf(dem);
+      if (!dem.isEmpty()) {
+        this.dem = Integer.valueOf(dem);
+      }
       return this;
     }
 
@@ -428,7 +435,7 @@ public class City {
 
     public Builder modificationDate(String modificationDate) {
       try {
-        this.modificationDate = LocalDate.parse(modificationDate, DATE_TIME_FORMATTER);
+        this.modificationDate = LocalDate.parse(modificationDate.replace("\n", ""), DATE_TIME_FORMATTER);
       } catch (DateTimeParseException e) {
         this.modificationDate = null;
       }
@@ -436,7 +443,9 @@ public class City {
     }
 
     public Builder population(String population) {
-      this.population = Long.valueOf(population);
+      if (!population.isEmpty()) {
+        this.population = Long.valueOf(population);
+      }
       return this;
     }
 

--- a/domain/src/test/java/org/citybackend/city/CityTest.java
+++ b/domain/src/test/java/org/citybackend/city/CityTest.java
@@ -39,7 +39,7 @@ public class CityTest {
   }
 
   @Test
-  public void invalidLatitude_replacedByNull() {
+  public void invalidLatitude_isNull() {
     City city = new City.Builder()
         .geonameId("geoname id")
         .name("name")
@@ -66,7 +66,7 @@ public class CityTest {
   }
 
   @Test
-  public void invalidLongitude_replacedByNull() {
+  public void invalidLongitude_isNull() {
     City city = new City.Builder()
         .geonameId("geoname id")
         .name("name")
@@ -93,7 +93,7 @@ public class CityTest {
   }
 
   @Test
-  public void invalidDate_replacedByDateOfNow() {
+  public void invalidDate_isNull() {
     City city = new City.Builder()
         .geonameId("geoname id")
         .name("name")
@@ -120,7 +120,7 @@ public class CityTest {
   }
 
   @Test
-  public void invalidTimeZone_replacedByNull() {
+  public void invalidTimeZone_isNull() {
     City city = new City.Builder()
         .geonameId("geoname id")
         .name("name")
@@ -144,5 +144,36 @@ public class CityTest {
         .build();
 
     assertThat(city.getTimeZone()).isNull();
+  }
+
+  @Test
+  public void emptyNumber_isNull() {
+    City city = new City.Builder()
+        .geonameId("geoname id")
+        .name("name")
+        .asciiName("asciiName value")
+        .alternateNames("alternateName0,alternateName1")
+        .latitude("")
+        .longitude("")
+        .featureClass("featureClass value")
+        .featureCode("featureCode value")
+        .countryCode("CA")
+        .alternateCountryCode("CA")
+        .admin1("admin1 value")
+        .admin2("admin2 value")
+        .admin3("admin3 value")
+        .admin4("admin4 value")
+        .population("")
+        .elevation("")
+        .dem("")
+        .timeZone("America/Montreal")
+        .modificationDate("2020-08-07")
+        .build();
+
+    assertThat(city.getLongitude()).isNull();
+    assertThat(city.getLatitude()).isNull();
+    assertThat(city.getPopulation()).isNull();
+    assertThat(city.getElevation()).isNull();
+    assertThat(city.getDem()).isNull();
   }
 }


### PR DESCRIPTION
This PR provides a bug fix: interpret empty strings as null when they are supposed to match a number.