### PR TITLE
fix: empty string interpretation for alternateNames

### DIFF
--- a/domain/src/main/java/org/citybackend/city/City.java
+++ b/domain/src/main/java/org/citybackend/city/City.java
@@ -346,7 +346,11 @@ public class City {
     }
 
     public Builder alternateNames(String alternateName) {
-      this.alternateNames = new HashSet<>(Arrays.asList(alternateName.split(COMMA_SEPARATOR)));
+      HashSet<String> names = new HashSet<>();
+      if (!alternateName.isEmpty()) {
+        names.addAll(Arrays.asList(alternateName.split(COMMA_SEPARATOR)));
+      }
+      this.alternateNames = names;
       return this;
     }
 
@@ -435,7 +439,8 @@ public class City {
 
     public Builder modificationDate(String modificationDate) {
       try {
-        this.modificationDate = LocalDate.parse(modificationDate.replace("\n", ""), DATE_TIME_FORMATTER);
+        this.modificationDate = LocalDate
+            .parse(modificationDate.replace("\n", ""), DATE_TIME_FORMATTER);
       } catch (DateTimeParseException e) {
         this.modificationDate = null;
       }

--- a/domain/src/test/java/org/citybackend/city/CityTest.java
+++ b/domain/src/test/java/org/citybackend/city/CityTest.java
@@ -39,6 +39,33 @@ public class CityTest {
   }
 
   @Test
+  public void emptyAlternateNames_isEmpty() {
+    City city = new City.Builder()
+        .geonameId("geoname id")
+        .name("name")
+        .asciiName("asciiName value")
+        .alternateNames("")
+        .latitude("45.90")
+        .longitude("53.33")
+        .featureClass("featureClass value")
+        .featureCode("featureCode value")
+        .countryCode("CA")
+        .alternateCountryCode("CA")
+        .admin1("admin1 value")
+        .admin2("admin2 value")
+        .admin3("admin3 value")
+        .admin4("admin4 value")
+        .population("5000000")
+        .elevation("300")
+        .dem("30000")
+        .timeZone("America/Toronto")
+        .modificationDate("2020-08-07")
+        .build();
+
+    assertThat(city.getAlternateNames()).isEmpty();
+  }
+
+  @Test
   public void invalidLatitude_isNull() {
     City city = new City.Builder()
         .geonameId("geoname id")


### PR DESCRIPTION
This PR fixes the interpretation of empty string for alternateNames