### PR TITLE
refactor: make TsvRowParser a singleton

### DIFF
--- a/processor/src/main/java/org/citybackend/parser/TsvRowParser.java
+++ b/processor/src/main/java/org/citybackend/parser/TsvRowParser.java
@@ -7,6 +7,29 @@ import org.citybackend.city.City;
  */
 public class TsvRowParser implements CityParser {
 
+  private static TsvRowParser entity = null;
+
+  private TsvRowParser() {
+  }
+
+  /**
+   * Returns the unique instance of {@code TsvRowParser}.
+   *
+   * @return the unique instance of {@code TsvRowParser}.
+   */
+  public static TsvRowParser getParser() {
+    if (entity == null) {
+      return new TsvRowParser();
+    }
+    return entity;
+  }
+
+  /**
+   * Return a {@code City} after parsing line from geonames.org.
+   *
+   * @param line the line to parse
+   * @return the {@code City} internat representation.
+   */
   @Override
   public City parse(String line) {
     // Because it's a tab separated file, split the line on the tab char.

--- a/processor/src/test/java/org/citybackend/parser/TsvRowParserTest.java
+++ b/processor/src/test/java/org/citybackend/parser/TsvRowParserTest.java
@@ -15,7 +15,7 @@ public class TsvRowParserTest {
   @Test
   public void lineWithValues_isParsedAsCity() {
     String line = "3424953\tVirgin Rocks\tVirgin Rocks\tVirgin roches,Virgin gros cailloux\t46.42886\t-50.81995\tU\tRFU\tCA\t\t01\t02\t03\t04\t0\t4548\t-9999\t\t2018-02-20\n";
-    TsvRowParser parser = new TsvRowParser();
+    CityParser parser = TsvRowParser.getParser();
     City city = parser.parse(line);
     assertThat(city.getGeonameId()).matches("3424953");
     assertThat(city.getName()).matches("Virgin Rocks");
@@ -42,7 +42,7 @@ public class TsvRowParserTest {
   @Test
   public void lineWithoutValues_isParsedAsCity() {
     String line = "\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\t\n";
-    TsvRowParser parser = new TsvRowParser();
+    CityParser parser = TsvRowParser.getParser();
     City city = parser.parse(line);
     assertThat(city.getGeonameId()).isEmpty();
     assertThat(city.getName()).isEmpty();


### PR DESCRIPTION
This PR provides support to only have 1 instance of `TsvRowParser` living.